### PR TITLE
added ListDrives metrics

### DIFF
--- a/pkg/prom/metrics.go
+++ b/pkg/prom/metrics.go
@@ -142,6 +142,10 @@ type Descriptions struct {
 	ClusterThresholdSumTotalMetadataClusterBytes   *prometheus.Desc
 	ClusterThresholdSumUsedClusterBytes            *prometheus.Desc
 	ClusterThresholdSumUsedMetadataClusterBytes    *prometheus.Desc
+
+	ListDrivesByStatusTotal *prometheus.Desc
+	ListDrivesByNodeTotal   *prometheus.Desc
+	ListDrivesByTypeTotal   *prometheus.Desc
 }
 
 func NewMetricDescriptions(namespace string) *Descriptions {
@@ -952,6 +956,27 @@ func NewMetricDescriptions(namespace string) *Descriptions {
 		prometheus.BuildFQName(namespace, "", "cluster_threshold_sum_used_metadata_cluster_bytes"),
 		"Amount of space used on volume drives to store metadata.",
 		nil,
+		nil,
+	)
+
+	d.ListDrivesByStatusTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "list_drives_by_status_count"),
+		"Number of drives per node and status",
+		[]string{"node_id", "node_name", "status"},
+		nil,
+	)
+
+	d.ListDrivesByNodeTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "list_drives_by_node_total"),
+		"Total number of drives per node",
+		[]string{"node_id", "node_name"},
+		nil,
+	)
+
+	d.ListDrivesByTypeTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "list_drives_by_type_count"),
+		"Number of drives per node and type",
+		[]string{"node_id", "node_name", "type"},
 		nil,
 	)
 

--- a/pkg/solidfire/solidfire.go
+++ b/pkg/solidfire/solidfire.go
@@ -261,3 +261,25 @@ func (s *Client) GetClusterFullThreshold() (GetClusterFullThresholdResponse, err
 	}
 	return r, nil
 }
+
+func (s *Client) ListDrives() (ListDrivesResponse, error) {
+	payload := &RPCBody{
+		Method: "ListDrives",
+		Params: ListDrivesParams{},
+		ID:     1,
+	}
+
+	payloadBytes, err := json.Marshal(&payload)
+	r := ListDrivesResponse{}
+	bodyBytes, err := doRpcCall(s, payloadBytes)
+
+	if err != nil {
+		return r, err
+	}
+	err = json.Unmarshal(bodyBytes, &r)
+
+	if err != nil {
+		return r, err
+	}
+	return r, nil
+}

--- a/pkg/solidfire/types.go
+++ b/pkg/solidfire/types.go
@@ -52,6 +52,10 @@ type GetClusterFullThresholdParams struct {
 	// No params needed
 }
 
+type ListDrivesParams struct {
+	// No params needed
+}
+
 type ListVolumesResponse struct {
 	ID     int `json:"id"`
 	Result struct {
@@ -385,5 +389,22 @@ type GetClusterFullThresholdResponse struct {
 		SumTotalMetadataClusterBytes   float64 `json:"sumTotalMetadataClusterBytes"`
 		SumUsedClusterBytes            float64 `json:"sumUsedClusterBytes"`
 		SumUsedMetadataClusterBytes    float64 `json:"sumUsedMetadataClusterBytes"`
+	} `json:"result"`
+}
+
+type ListDrivesResponse struct {
+	ID     int `json:"id"`
+	Result struct {
+		Drives []struct {
+			Attributes struct {
+			} `json:"attributes"`
+			Capacity int64   `json:"capacity"`
+			DriveID  float64 `json:"driveID"`
+			NodeID   int     `json:"nodeID"`
+			Serial   string  `json:"serial"`
+			Slot     float64 `json:"slot"`
+			Status   string  `json:"status"`
+			Type     string  `json:"type"`
+		} `json:"drives"`
 	} `json:"result"`
 }

--- a/test/fixtures/listdrives.json
+++ b/test/fixtures/listdrives.json
@@ -1,0 +1,47 @@
+{
+    "id": 1,
+    "result": {
+        "drives": [
+            {
+                "attributes": {},
+                "capacity": 299917139968,
+                "driveID": 35,
+                "nodeID": 5,
+                "serial": "scsi-SATA_INTEL_SSDSA2CW6CVPR141502R3600FGN-part2",
+                "slot": 0,
+                "status": "active",
+                "type": "volume"
+            },
+            {
+                "attributes": {},
+                "capacity": 600127266816,
+                "driveID": 36,
+                "nodeID": 5,
+                "serial": "scsi-SATA_INTEL_SSDSA2CW6CVPR1415037R600FGN",
+                "slot": 6,
+                "status": "active",
+                "type": "block"
+            },
+            {
+                "attributes": {},
+                "capacity": 600127266821,
+                "driveID": 37,
+                "nodeID": 5,
+                "serial": "scsi-SATA_INTEL_SSDSA2CW6CVPR1415037R600FGN",
+                "slot": 6,
+                "status": "active",
+                "type": "block"
+            },
+            {
+                "attributes": {},
+                "capacity": 600127266825,
+                "driveID": 38,
+                "nodeID": 5,
+                "serial": "scsi-SATA_INTEL_SSDSA2CW6CVPR1415037R600FGN",
+                "slot": 6,
+                "status": "active",
+                "type": "block"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- added ListDrives metrics

```
# HELP solidfire_list_drives_by_status_count Number of drives per node and status
# TYPE solidfire_list_drives_by_status_count gauge
solidfire_list_drives_by_status_count{node_id="1",node_name="store01",status="active"} 10
solidfire_list_drives_by_status_count{node_id="1",node_name="store01",status="available"} 0
solidfire_list_drives_by_status_count{node_id="1",node_name="store01",status="erasing"} 0
solidfire_list_drives_by_status_count{node_id="1",node_name="store01",status="failed"} 0
solidfire_list_drives_by_status_count{node_id="1",node_name="store01",status="removing"} 0
solidfire_list_drives_by_status_count{node_id="2",node_name="store02",status="active"} 10
solidfire_list_drives_by_status_count{node_id="2",node_name="store02",status="available"} 0
solidfire_list_drives_by_status_count{node_id="2",node_name="store02",status="erasing"} 0
solidfire_list_drives_by_status_count{node_id="2",node_name="store02",status="failed"} 0
solidfire_list_drives_by_status_count{node_id="2",node_name="store02",status="removing"} 0
solidfire_list_drives_by_status_count{node_id="3",node_name="store03",status="active"} 10
solidfire_list_drives_by_status_count{node_id="3",node_name="store03",status="available"} 0
solidfire_list_drives_by_status_count{node_id="3",node_name="store03",status="erasing"} 0
solidfire_list_drives_by_status_count{node_id="3",node_name="store03",status="failed"} 0
solidfire_list_drives_by_status_count{node_id="3",node_name="store03",status="removing"} 0
solidfire_list_drives_by_status_count{node_id="4",node_name="store04",status="active"} 10
solidfire_list_drives_by_status_count{node_id="4",node_name="store04",status="available"} 0
solidfire_list_drives_by_status_count{node_id="4",node_name="store04",status="erasing"} 0
solidfire_list_drives_by_status_count{node_id="4",node_name="store04",status="failed"} 0
solidfire_list_drives_by_status_count{node_id="4",node_name="store04",status="removing"} 0
```