### PR TITLE
Remove ISCSI volume node id 

### DIFF
--- a/pkg/prom/collector.go
+++ b/pkg/prom/collector.go
@@ -163,7 +163,7 @@ func (c *solidfireCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- MetricDescriptions.ListDrivesCapacity
 
 	ch <- MetricDescriptions.NodeISCSISessionsTotal
-	ch <- MetricDescriptions.NodeISCSIVolumes
+	//	ch <- MetricDescriptions.NodeISCSIVolumes
 }
 
 func (c *solidfireCollector) Collect(ch chan<- prometheus.Metric) {
@@ -1227,13 +1227,13 @@ func (c *solidfireCollector) Collect(ch chan<- prometheus.Metric) {
 				volumeNamesByID[vol],
 			)
 
-			ch <- prometheus.MustNewConstMetric(
-				MetricDescriptions.NodeISCSIVolumes,
-				prometheus.GaugeValue,
-				float64(node),
-				strconv.Itoa(vol),
-				volumeNamesByID[vol],
-			)
+			// ch <- prometheus.MustNewConstMetric(
+			// 	MetricDescriptions.NodeISCSIVolumes,
+			// 	prometheus.GaugeValue,
+			// 	float64(node),
+			// 	strconv.Itoa(vol),
+			// 	volumeNamesByID[vol],
+			// )
 
 		}
 	}

--- a/pkg/prom/metrics.go
+++ b/pkg/prom/metrics.go
@@ -145,7 +145,7 @@ type Descriptions struct {
 	ListDrivesCapacity *prometheus.Desc
 
 	NodeISCSISessionsTotal *prometheus.Desc
-	NodeISCSIVolumes       *prometheus.Desc
+	//NodeISCSIVolumes       *prometheus.Desc
 }
 
 func NewMetricDescriptions(namespace string) *Descriptions {
@@ -966,12 +966,12 @@ func NewMetricDescriptions(namespace string) *Descriptions {
 		nil,
 	)
 
-	d.NodeISCSIVolumes = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "volume_node_id"),
-		"The node id where the volume is hosted.",
-		[]string{"volume_id", "volume_name"},
-		nil,
-	)
+	// d.NodeISCSIVolumes = prometheus.NewDesc(
+	// 	prometheus.BuildFQName(namespace, "", "volume_node_id"),
+	// 	"The node id where the volume is hosted.",
+	// 	[]string{"volume_id", "volume_name"},
+	// 	nil,
+	// )
 
 	return &d
 }


### PR DESCRIPTION
- Remove ISCSI volume node id as this is not the correct value to use for this metric
- Potentially errors out if the volume has multiple ISCSI sessions