### PR TITLE
Added configurable timeout per RPC call; Improved error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Usage of solidfire-exporter:
   -p, --password string   Password with which to authenticate to the Solidfire API. May also be set by environment variable SOLIDFIRE_PASS. (default "my_solidfire_password")
   -e, --endpoint string   Endpoint for the Solidfire API. May also be set by environment variable SOLIDFIRE_RPC_ENDPOINT. (default "https://192.168.1.2/json-rpc/11.3")
   -i, --insecure          Whether to disable TLS validation when calling the Solidfire API. May also be set by environment variable INSECURE_SKIP_VERIFY.
+  -t, --timeout int       HTTP Client timeout (in seconds) per call to Solidfire API. (default 30)
 ```
 
 ## Volume QoS

--- a/cmd/solidfire-exporter/main.go
+++ b/cmd/solidfire-exporter/main.go
@@ -26,6 +26,7 @@ func init() {
 	flag.StringP(solidfire.PasswordFlag, "p", "my_solidfire_password", fmt.Sprintf("Password with which to authenticate to the Solidfire API. May also be set by environment variable %v.", solidfire.PasswordFlagEnv))
 	flag.StringP(solidfire.EndpointFlag, "e", "https://192.168.1.2/json-rpc/11.3", fmt.Sprintf("Endpoint for the Solidfire API. May also be set by environment variable %v.", solidfire.EndpointFlagEnv))
 	flag.BoolP(solidfire.InsecureSSLFlag, "i", false, fmt.Sprintf("Whether to disable TLS validation when calling the Solidfire API. May also be set by environment variable %v.", solidfire.InsecureSSLFlagEnv))
+	flag.Int64P(solidfire.HTTPClientTimeoutFlag, "t", 30, fmt.Sprintf("HTTP Client timeout (in seconds) per call to Solidfire API."))
 	flag.Parse()
 
 	// PORT environment variable takes precedence in order to be backwards-compatible

--- a/pkg/solidfire/solidfire.go
+++ b/pkg/solidfire/solidfire.go
@@ -29,7 +29,7 @@ func NewSolidfireClient() *Client {
 	return &Client{
 		HttpClient: &http.Client{
 			Transport: tr,
-			Timeout:   30 * time.Second,
+			Timeout:   time.Duration(viper.GetInt64(HTTPClientTimeoutFlag)) * time.Second,
 		},
 		Username:    viper.GetString(UsernameFlag),
 		Password:    viper.GetString(PasswordFlag),
@@ -38,13 +38,12 @@ func NewSolidfireClient() *Client {
 }
 
 func doRpcCall(c *Client, body []byte) ([]byte, error) {
-
 	req, err := http.NewRequest("POST", c.RPCEndpoint, bytes.NewReader(body))
 	req.SetBasicAuth(c.Username, c.Password)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := c.HttpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Error making RPC call: %v", err)
+		return nil, fmt.Errorf("Error making RPC call %v: %v", string(body), err)
 	}
 
 	defer resp.Body.Close()

--- a/pkg/solidfire/types.go
+++ b/pkg/solidfire/types.go
@@ -6,16 +6,17 @@ import (
 )
 
 var (
-	ListenPortFlag     = "listenPort"
-	UsernameFlag       = "username"
-	PasswordFlag       = "password"
-	EndpointFlag       = "endpoint"
-	InsecureSSLFlag    = "insecure"
-	ListenPortFlagEnv  = "SOLIDFIRE_PORT"
-	UsernameFlagEnv    = "SOLIDFIRE_USER"
-	PasswordFlagEnv    = "SOLIDFIRE_PASS"
-	EndpointFlagEnv    = "SOLIDFIRE_RPC_ENDPOINT"
-	InsecureSSLFlagEnv = "INSECURE_SKIP_VERIFY"
+	ListenPortFlag        = "listenPort"
+	UsernameFlag          = "username"
+	PasswordFlag          = "password"
+	EndpointFlag          = "endpoint"
+	InsecureSSLFlag       = "insecure"
+	HTTPClientTimeoutFlag = "timeout"
+	ListenPortFlagEnv     = "SOLIDFIRE_PORT"
+	UsernameFlagEnv       = "SOLIDFIRE_USER"
+	PasswordFlagEnv       = "SOLIDFIRE_PASS"
+	EndpointFlagEnv       = "SOLIDFIRE_RPC_ENDPOINT"
+	InsecureSSLFlagEnv    = "INSECURE_SKIP_VERIFY"
 )
 
 type Client struct {


### PR DESCRIPTION
- Adds timeout flag for configurable timeout per-RPC call
- Improve error logging by also showing the POST payload body so we can track which calls timed out

Adds additional debugging features to assist with #22 