### PR TITLE
fix(#43): fix efficiency factor NaN calculation

### DIFF
--- a/pkg/prom/collector.go
+++ b/pkg/prom/collector.go
@@ -527,18 +527,30 @@ func (c *solidfireCollector) Collect(ch chan<- prometheus.Metric) {
 		cluster.ZeroBlocks)
 
 	clusterThinProvisioningFactor := (cluster.NonZeroBlocks + cluster.ZeroBlocks) / cluster.NonZeroBlocks
+	if cluster.NonZeroBlocks == 0 {
+		clusterThinProvisioningFactor = 1
+	}
+
 	ch <- prometheus.MustNewConstMetric(
 		MetricDescriptions.ClusterCapacityThinProvisioningFactor,
 		prometheus.GaugeValue,
 		clusterThinProvisioningFactor)
 
 	clusterDeDuplicationFactor := (cluster.NonZeroBlocks + cluster.SnapshotNonZeroBlocks) / cluster.UniqueBlocks
+	if cluster.UniqueBlocks == 0 {
+		clusterDeDuplicationFactor = 1
+	}
+
 	ch <- prometheus.MustNewConstMetric(
 		MetricDescriptions.ClusterCapacityDeDuplicationFactor,
 		prometheus.GaugeValue,
 		clusterDeDuplicationFactor)
 
 	clusterCompressionFactor := (cluster.UniqueBlocks * 4096) / (cluster.UniqueBlocksUsedSpace * 0.93)
+	if cluster.UniqueBlocksUsedSpace == 0 {
+		clusterCompressionFactor = 1
+	}
+
 	ch <- prometheus.MustNewConstMetric(
 		MetricDescriptions.ClusterCapacityCompressionFactor,
 		prometheus.GaugeValue,


### PR DESCRIPTION
On small (test) clusters that have minimal or no data, there
were 'divide by zero' errors for thin provisioning factor,
deduplication factor, and compression factor.

On a cluster with no data, the efficiency factor should just be
'1', as reported by the solidfire GUI.

It was recommended by @scaleoutsean to default to '1' if there are
no blocks used on the cluster, thus avoiding any divide by zero errors
when calculating these factors.

Fixes #43 