### PR TITLE
fix: sum iscsi sessions for all volumes per node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ Example Format Below:
 - Fix Markdown links to tag comparison URL with footnote-style links.
 -->
 ## [Unreleased]
-
+### Fixed
+- Sum ISCSI sessions for all volumes per node in singlestat panel #59 
 ## [0.6.0] - 2021-04-17
 ### Added
 - Added CHANGELOG

--- a/cmd/dashboards/node/node.go
+++ b/cmd/dashboards/node/node.go
@@ -91,7 +91,7 @@ func NewNodeDetailDashboard() dashboard.Builder {
 				singlestat.SparkLine(),
 				singlestat.Colors([3]string{common.ColorGreen, common.ColorGreen, common.ColorGreen}),
 				singlestat.WithPrometheusTarget(
-					fmt.Sprintf(`solidfire_node_iscsi_sessions{sfcluster=~"%s", node_name=~"%s"}`,
+					fmt.Sprintf(`sum(solidfire_node_iscsi_sessions{sfcluster=~"%s", node_name=~"%s"}) by (sfcluster,node_name)`,
 						common.ClusterVar, common.NodeVar,
 					),
 				),

--- a/dashboards/solidfire-node-detail.json
+++ b/dashboards/solidfire-node-detail.json
@@ -197,7 +197,7 @@
           "targets": [
             {
               "refId": "",
-              "expr": "solidfire_node_iscsi_sessions{sfcluster=~\"$sfcluster\", node_name=~\"$node\"}",
+              "expr": "sum(solidfire_node_iscsi_sessions{sfcluster=~\"$sfcluster\", node_name=~\"$node\"}) by (sfcluster,node_name)",
               "format": "time_series"
             }
           ],


### PR DESCRIPTION
iscsi sessions are per volume, so we need to sum them before displaying in a singlestat
![image](https://user-images.githubusercontent.com/8252744/115169968-1d716f80-a085-11eb-8246-e471822f9cb5.png)
